### PR TITLE
Add Ethereum testnet definitions, Goerli and Sepolia

### DIFF
--- a/cert_core/__init__.py
+++ b/cert_core/__init__.py
@@ -7,6 +7,8 @@ CHAIN_BITCOIN_REGTEST = 'bitcoinRegtest'
 CHAIN_BITCOIN_TESTNET = 'bitcoinTestnet'
 CHAIN_ETHEREUM_MAINNET = 'ethereumMainnet'
 CHAIN_ETHEREUM_ROPSTEN = 'ethereumRopsten'
+CHAIN_ETHEREUM_GOERLI = 'ethereumGoerli'
+CHAIN_ETHEREUM_SEPOLIA = 'ethereumSepolia'
 CHAIN_MOCKCHAIN = 'mockchain'
 
 # system value for chains, including specific network. Used in config files for example
@@ -15,6 +17,8 @@ SYS_CHAIN_BITCOIN_REGTEST = 'bitcoin_regtest'
 SYS_CHAIN_BITCOIN_TESTNET = 'bitcoin_testnet'
 SYS_CHAIN_ETHEREUM_MAINNET = 'ethereum_mainnet'
 SYS_CHAIN_ETHEREUM_ROPSTEN = 'ethereum_ropsten'
+SYS_CHAIN_ETHEREUM_GOERLI = 'ethereum_goerli'
+SYS_CHAIN_ETHEREUM_SEPOLIA = 'ethereum_sepolia'
 SYS_CHAIN_MOCKCHAIN = 'mockchain'
 
 # signature type, part of signature suite standard
@@ -57,6 +61,8 @@ class Chain(Enum):
     mockchain = 3, BlockchainType.mock, CHAIN_MOCKCHAIN
     ethereum_mainnet = 4, BlockchainType.ethereum, CHAIN_ETHEREUM_MAINNET
     ethereum_ropsten = 5, BlockchainType.ethereum, CHAIN_ETHEREUM_ROPSTEN
+    ethereum_goerli = 6, BlockchainType.ethereum, CHAIN_ETHEREUM_GOERLI
+    ethereum_sepolia = 7, BlockchainType.ethereum, CHAIN_ETHEREUM_SEPOLIA
 
     def __new__(cls, enum_value, blockchain_type, external_display_value):
         obj = object.__new__(cls)
@@ -79,6 +85,10 @@ class Chain(Enum):
             return Chain.ethereum_mainnet
         elif chain_string == SYS_CHAIN_ETHEREUM_ROPSTEN:
             return Chain.ethereum_ropsten
+        elif chain_string == SYS_CHAIN_ETHEREUM_GOERLI:
+            return Chain.ethereum_goerli
+        elif chain_string == SYS_CHAIN_ETHEREUM_SEPOLIA:
+            return Chain.ethereum_sepolia
         else:
             raise UnknownChainError(chain_string)
 
@@ -96,6 +106,10 @@ class Chain(Enum):
             return Chain.ethereum_mainnet
         elif external_display_value == CHAIN_ETHEREUM_ROPSTEN:
             return Chain.ethereum_ropsten
+        elif external_display_value == CHAIN_ETHEREUM_GOERLI:
+            return Chain.ethereum_goerli
+        elif external_display_value == CHAIN_ETHEREUM_SEPOLIA:
+            return Chain.ethereum_sepolia
         else:
             raise UnknownChainError(external_display_value)
 

--- a/cert_core/__init__.py
+++ b/cert_core/__init__.py
@@ -113,6 +113,15 @@ class Chain(Enum):
         else:
             raise UnknownChainError(external_display_value)
 
+    def is_bitcoin_type(self):
+        return self.blockchain_type == BlockchainType.bitcoin
+
+    def is_mock_type(self):
+        return self.blockchain_type == BlockchainType.mock
+
+    def is_ethereum_type(self):
+        return self.blockchain_type == BlockchainType.ethereum
+
 
 def chain_to_bitcoin_network(chain):
     """

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open(os.path.join(here, 'README.md')) as fp:
 
 setup(
     name='cert-core',
-    version='3.0.0b1',
+    version='3.0.0',
     description='Blockcerts core models for python',
     author='info@blockcerts.org',
     tests_require=['tox'],

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -44,6 +44,14 @@ class TestInit(unittest.TestCase):
         chain = Chain.parse_from_chain('ethereum_ropsten')
         self.assertEqual(chain, Chain.ethereum_ropsten)
 
+    def test_parse_from_chain_string_ethereum_goerli(self):
+        chain = Chain.parse_from_chain('ethereum_goerli')
+        self.assertEqual(chain, Chain.ethereum_goerli)
+
+    def test_parse_from_chain_string_ethereum_sepolia(self):
+        chain = Chain.parse_from_chain('ethereum_sepolia')
+        self.assertEqual(chain, Chain.ethereum_sepolia)
+
     def test_parse_from_chain_string_mockchain(self):
         chain = Chain.parse_from_chain('mockchain')
         self.assertEqual(chain, Chain.mockchain)
@@ -67,6 +75,14 @@ class TestInit(unittest.TestCase):
     def test_parse_from_external_display_value_ethereum_ropsten(self):
         chain = Chain.parse_from_external_display_value('ethereumRopsten')
         self.assertEqual(chain, Chain.ethereum_ropsten)
+
+    def test_parse_from_external_display_value_ethereum_goerli(self):
+        chain = Chain.parse_from_external_display_value('ethereumGoerli')
+        self.assertEqual(chain, Chain.ethereum_goerli)
+
+    def test_parse_from_external_display_value_ethereum_sepolia(self):
+        chain = Chain.parse_from_external_display_value('ethereumSepolia')
+        self.assertEqual(chain, Chain.ethereum_sepolia)
 
     def test_parse_from_external_display_value_mockchain(self):
         chain = Chain.parse_from_external_display_value('mockchain')

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -100,6 +100,44 @@ class TestInit(unittest.TestCase):
         netcode = chain_to_bitcoin_network(Chain.bitcoin_regtest)
         self.assertEqual(netcode, 'regtest')
 
+    def test_parse_from_external_display_value_bitcoin_mainnet(self):
+        chain = Chain.parse_from_external_display_value('bitcoinMainnet')
+        self.assertEqual(chain, Chain.bitcoin_mainnet)
+
+    def test_parse_from_external_display_value_bitcoin_mainnet(self):
+        chain = Chain.parse_from_external_display_value('bitcoinMainnet')
+        self.assertEqual(chain, Chain.bitcoin_mainnet)
+
+    def test_is_bitcoin_type_works_for_all_the_members(self):
+        self.assertEqual(Chain.bitcoin_mainnet.is_bitcoin_type(), True)
+        self.assertEqual(Chain.bitcoin_testnet.is_bitcoin_type(), True)
+        self.assertEqual(Chain.bitcoin_regtest.is_bitcoin_type(), True)
+        self.assertEqual(Chain.mockchain.is_bitcoin_type(), False)
+        self.assertEqual(Chain.ethereum_mainnet.is_bitcoin_type(), False)
+        self.assertEqual(Chain.ethereum_ropsten.is_bitcoin_type(), False)
+        self.assertEqual(Chain.ethereum_goerli.is_bitcoin_type(), False)
+        self.assertEqual(Chain.ethereum_sepolia.is_bitcoin_type(), False)
+
+    def test_is_mock_type_works_for_all_the_members(self):
+        self.assertEqual(Chain.bitcoin_mainnet.is_mock_type(), False)
+        self.assertEqual(Chain.bitcoin_testnet.is_mock_type(), False)
+        self.assertEqual(Chain.bitcoin_regtest.is_mock_type(), False)
+        self.assertEqual(Chain.mockchain.is_mock_type(), True)
+        self.assertEqual(Chain.ethereum_mainnet.is_mock_type(), False)
+        self.assertEqual(Chain.ethereum_ropsten.is_mock_type(), False)
+        self.assertEqual(Chain.ethereum_goerli.is_mock_type(), False)
+        self.assertEqual(Chain.ethereum_sepolia.is_mock_type(), False)
+
+    def test_is_ethereum_type_works_for_all_the_members(self):
+        self.assertEqual(Chain.bitcoin_mainnet.is_ethereum_type(), False)
+        self.assertEqual(Chain.bitcoin_testnet.is_ethereum_type(), False)
+        self.assertEqual(Chain.bitcoin_regtest.is_ethereum_type(), False)
+        self.assertEqual(Chain.mockchain.is_ethereum_type(), False)
+        self.assertEqual(Chain.ethereum_mainnet.is_ethereum_type(), True)
+        self.assertEqual(Chain.ethereum_ropsten.is_ethereum_type(), True)
+        self.assertEqual(Chain.ethereum_goerli.is_ethereum_type(), True)
+        self.assertEqual(Chain.ethereum_sepolia.is_ethereum_type(), True)
+
     def test_bitcoin_chain_to_netcode_mocknet(self):
         """
         This should fail. Assert that we get an UnknownChainError


### PR DESCRIPTION
Hi maintainers,

This PR is to add Ethereum testnet definitions, the Goerli and the Sepolia.
We have discussed this on [this forum page](https://community.blockcerts.org/t/ethereum-announced-the-testnet-ropsten-would-be-closed-in-q4-2022/3227).
Could you check this?

I checked that `run_tests.sh`could run and pass.